### PR TITLE
Remove omitempty tag of User.active

### DIFF
--- a/user.go
+++ b/user.go
@@ -12,7 +12,7 @@ package scim
 type User struct {
 
 	// user status
-	Active bool `json:"active,omitempty"`
+	Active bool `json:"active"`
 
 	Addresses []Address `json:"addresses,omitempty"`
 


### PR DESCRIPTION
`User.Active` が `false` のときに、このパラメータが省略されていまい、SCIM サービス側のデフォルト値が採用されてしまうため、`omitempty` を外して `false` のときにも正しくリクエストパラメータが作成されるようにしました